### PR TITLE
Prevent PassthroughWindow from overriding status bar style

### DIFF
--- a/Sources/PassthroughWindow.swift
+++ b/Sources/PassthroughWindow.swift
@@ -42,4 +42,13 @@ final class PassthroughWindow: UIWindow {
     }
 
     private weak var hitTestView: UIView?
+    
+    /// Private API overrides for status bar appearance
+    /// http://www.openradar.me/15573442
+    /// http://www.openradar.me/30064691
+    /// https://openradar.appspot.com/23677818
+    @objc(_canAffectStatusBarAppearance)
+    private var canAffectStatusBarAppearance: Bool {
+        false
+    }
 }


### PR DESCRIPTION
Hi! When presenting `Drop` above view controller that has `preferredStatusBarStyle` set to `.lightContent` there is a bug. Status bar turns to black while `Drop` is presented, and turn back to expected color (white) when dismissed. This PR fix this behaviour using `UIWindow`'s private API override. There are several open radars related to this, but none of them is fixed. This fix is totally safe and we are using it in App Store without any issues for three years now.