### PR TITLE
Provide a customisation of maximum number of lines for title and subtitle

### DIFF
--- a/Sources/Drop.swift
+++ b/Sources/Drop.swift
@@ -28,7 +28,9 @@ public struct Drop: ExpressibleByStringLiteral {
     /// Create a new drop.
     /// - Parameters:
     ///   - title: Title.
+    ///   - titleNumberOfLines: Maximum number of lines that `title` can occupy. Defaults to `1`. A value of 0 means no limit.
     ///   - subtitle: Optional subtitle. Defaults to `nil`.
+    ///   - subtitleNumberOfLines: Maximum number of lines that `subtitle` can occupy. Defaults to `1`. A value of 0 means no limit.
     ///   - icon: Optional icon.
     ///   - action: Optional action.
     ///   - position: Position. Defaults to `Drop.Position.top`.
@@ -36,7 +38,9 @@ public struct Drop: ExpressibleByStringLiteral {
     ///   - accessibility: Accessibility options. Defaults to `nil` which will use "title, subtitle" as its message.
     public init(
         title: String,
+        titleNumberOfLines: Int = 1,
         subtitle: String? = nil,
+        subtitleNumberOfLines: Int = 1,
         icon: UIImage? = nil,
         action: Action? = nil,
         position: Position = .top,
@@ -44,9 +48,11 @@ public struct Drop: ExpressibleByStringLiteral {
         accessibility: Accessibility? = nil
     ) {
         self.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.titleNumberOfLines = titleNumberOfLines
         if let subtitle = subtitle?.trimmingCharacters(in: .whitespacesAndNewlines), !subtitle.isEmpty {
             self.subtitle = subtitle
         }
+        self.subtitleNumberOfLines = subtitleNumberOfLines
         self.icon = icon
         self.action = action
         self.position = position
@@ -59,6 +65,8 @@ public struct Drop: ExpressibleByStringLiteral {
     /// - Parameter message: Message to be announced when the drop is shown. Defaults to drop's "title, subtitle"
     public init(stringLiteral title: String) {
         self.title = title
+        self.titleNumberOfLines = 1
+        self.subtitleNumberOfLines = 1
         self.position = .top
         self.duration = .recommended
         self.accessibility = .init(message: title)
@@ -66,9 +74,15 @@ public struct Drop: ExpressibleByStringLiteral {
 
     /// Title.
     public var title: String
+    
+    /// Maximum number of lines that `title` can occupy. Defaults to `1`. A value of 0 means no limit.
+    public var titleNumberOfLines: Int
 
     /// Subtitle.
     public var subtitle: String?
+    
+    /// Maximum number of lines that `subtitle` can occupy. Defaults to `1`. A value of 0 means no limit.
+    public var subtitleNumberOfLines: Int
 
     /// Icon.
     public var icon: UIImage?

--- a/Sources/DropView.swift
+++ b/Sources/DropView.swift
@@ -107,8 +107,10 @@ internal final class DropView: UIView {
         clipsToBounds = true
 
         titleLabel.text = drop.title
+        titleLabel.numberOfLines = drop.titleNumberOfLines
 
         subtitleLabel.text = drop.subtitle
+        subtitleLabel.numberOfLines = drop.subtitleNumberOfLines
         subtitleLabel.isHidden = drop.subtitle == nil
 
         imageView.image = drop.icon
@@ -139,7 +141,6 @@ internal final class DropView: UIView {
     lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 1
         label.textAlignment = .center
         if #available(iOS 13.0, *) {
             label.textColor = .label
@@ -154,7 +155,6 @@ internal final class DropView: UIView {
     lazy var subtitleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 1
         label.textAlignment = .center
         if #available(iOS 13.0, *) {
             label.textColor = UIAccessibility.isDarkerSystemColorsEnabled ? .label : .secondaryLabel


### PR DESCRIPTION
Hi! I find your library very powerful and like it much more than `SPIndicator`. And I'd find it very nice to have a possibility to show `Drop`s with multiline text. So this PR adds two properties to `Drop` struct to control `numberOfLines` of title and subtitle `UILabel`s.