### PR TITLE
Add `willShow` notification to `Drop` presentation

### DIFF
--- a/Sources/Drops.swift
+++ b/Sources/Drops.swift
@@ -130,7 +130,6 @@ public final class Drops {
             guard let self = self else { return }
             guard let current = self.current else { return }
 
-            current.willShow?()
             current.show { completed in
                 guard completed else {
                     self.dispatchQueue.sync {

--- a/Sources/Drops.swift
+++ b/Sources/Drops.swift
@@ -34,8 +34,9 @@ public final class Drops {
 
     /// Show a drop.
     /// - Parameter drop: `Drop` to show.
-    public static func show(_ drop: Drop) {
-        shared.show(drop)
+    /// - Parameter willShow: The closure to be executed when `Drop` is about to be added to a view hierarchy.
+    public static func show(_ drop: Drop, willShow: (() -> Void)? = nil) {
+        shared.show(drop, willShow: willShow)
     }
 
     /// Hide currently shown drop.
@@ -58,9 +59,10 @@ public final class Drops {
 
     /// Show a drop.
     /// - Parameter drop: `Drop` to show.
-    public func show(_ drop: Drop) {
+    /// - Parameter willShow: The closure to be executed when `Drop` is about to be added to a view hierarchy.
+    public func show(_ drop: Drop, willShow: (() -> Void)? = nil) {
         DispatchQueue.main.async {
-            let presenter = Presenter(drop: drop, delegate: self)
+            let presenter = Presenter(drop: drop, delegate: self, willShow: willShow)
             self.enqueue(presenter: presenter)
         }
     }
@@ -128,6 +130,7 @@ public final class Drops {
             guard let self = self else { return }
             guard let current = self.current else { return }
 
+            current.willShow?()
             current.show { completed in
                 guard completed else {
                     self.dispatchQueue.sync {

--- a/Sources/Presenter.swift
+++ b/Sources/Presenter.swift
@@ -24,8 +24,9 @@
 import UIKit
 
 final class Presenter: NSObject {
-    init(drop: Drop, delegate: AnimatorDelegate) {
+    init(drop: Drop, delegate: AnimatorDelegate, willShow: (() -> Void)?) {
         self.drop = drop
+        self.willShow = willShow
         self.view = DropView(drop: drop)
         self.viewController = .init(value: WindowViewController())
         self.animator = Animator(position: drop.position, delegate: delegate)
@@ -33,6 +34,7 @@ final class Presenter: NSObject {
     }
 
     let drop: Drop
+    let willShow: (() -> Void)?
     let animator: Animator
     var isHiding = false
 

--- a/Sources/Presenter.swift
+++ b/Sources/Presenter.swift
@@ -40,6 +40,7 @@ final class Presenter: NSObject {
 
     func show(completion: @escaping AnimationCompletion) {
         install()
+        willShow?()
         animator.show(context: context) { [weak self] completed in
             if let drop = self?.drop {
                 self?.announcementAccessibilityMessage(for: drop)


### PR DESCRIPTION
Hi! This PR adds optional `willShow` parameter to `Drops.show(_:)` method to notify user that `Drop` is about to appear. I.e. it can be used to provide haptic feedback like it is done in [SPIndicator](https://github.com/ivanvorobei/SPIndicator), but since `Drops` are automatically enqueued, now it's impossible to say when you should send such feedback.