### PR TITLE
Fix `Drop` position in multi window environment

### DIFF
--- a/Sources/WindowViewController.swift
+++ b/Sources/WindowViewController.swift
@@ -47,11 +47,15 @@ internal final class WindowViewController: UIViewController {
     func install() {
         window?.frame = UIScreen.main.bounds
         window?.isHidden = false
-        if #available(iOS 13, *) {
+        if
+            let window = window,
+            #available(iOS 13, *),
             let activeScene = UIApplication.shared.connectedScenes
-                .compactMap { $0 as? UIWindowScene }
-                .first { $0.activationState == .foregroundActive }
-            window?.windowScene = activeScene
+                .compactMap({ $0 as? UIWindowScene })
+                .first(where: { $0.activationState == .foregroundActive })
+        {
+            window.windowScene = activeScene
+            window.frame = activeScene.coordinateSpace.bounds
         }
     }
 


### PR DESCRIPTION
Hi! There is a bug when displaying `Drop` in split-screen mode or in macCatalyst:
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-10-14 at 20 03 12](https://user-images.githubusercontent.com/23170237/137367758-ba0ec946-8f18-492c-a420-d03035715d6b.png)
This PR fixes it by using active `UIWindowScene`'s bounds.