### PR TITLE
Make hiding speed of bottom drop the same as top

### DIFF
--- a/Sources/Animator.swift
+++ b/Sources/Animator.swift
@@ -124,7 +124,7 @@ internal final class Animator {
         case .top:
           view?.transform = CGAffineTransform(translationX: 0, y: -frame.height)
         case .bottom:
-          view?.transform = CGAffineTransform(translationX: 0, y: frame.maxY + frame.height)
+          view?.transform = CGAffineTransform(translationX: 0, y: frame.height)
         }
       },
       completion: completion


### PR DESCRIPTION
Thanks for creating great project.

I found that hiding speed of drops is too fast when position is `.bottom`. This PR makes hiding speed of bottom drops the same as top. Please close this PR if the current behavior is intentional.

| before | after | top (for reference) |
| --- | --- | --- |
| ![2022-10-18 14 28 51](https://user-images.githubusercontent.com/22269397/196345001-e2208889-c65a-4d0c-99b8-60458865feb2.gif) | ![2022-10-18 14 30 09](https://user-images.githubusercontent.com/22269397/196344847-1360194e-ca9f-475d-9778-131fdddd5632.gif) | ![2022-10-18 14 29 19](https://user-images.githubusercontent.com/22269397/196345040-df882cc8-514f-40a8-8d2b-9fafab5e3d74.gif) |